### PR TITLE
Use properties instead of method calls for the coordinator

### DIFF
--- a/custom_components/linksys_velop/data_update_coordinator.py
+++ b/custom_components/linksys_velop/data_update_coordinator.py
@@ -47,9 +47,9 @@ class LinksysVelopDataUpdateCoordinator(DataUpdateCoordinator):
         try:
             await self._mesh.async_gather_details()
             async_dispatcher_send(self._hass, SIGNAL_UPDATE_PARENTAL_CONTROL_STATUS)
-            if await self._mesh.async_get_speedtest_state():
+            if self._mesh.speedtest_status:
                 async_dispatcher_send(self._hass, SIGNAL_UPDATE_SPEEDTEST_STATUS)
-            if await self._mesh.async_get_update_state():
+            if self._mesh.check_for_update_status:
                 async_dispatcher_send(self._hass, SIGNAL_UPDATE_CHECK_FOR_UPDATES_STATUS)
         except Exception as err:
             _LOGGER.error(err)

--- a/custom_components/linksys_velop/manifest.json
+++ b/custom_components/linksys_velop/manifest.json
@@ -7,7 +7,7 @@
   "issue_tracker": "https://github.com/uvjim/linksys_velop/issues",
   "name": "Linksys Velop",
   "requirements": [
-    "pyvelop>=2021.9.5"
+    "pyvelop>=2021.9.7"
   ],
   "version": "2021.9.1"
 }


### PR DESCRIPTION
Bumps the requirement for pyvelop