### PR TITLE
Add adapter type to online devices and connected devices

### DIFF
--- a/custom_components/linksys_velop/manifest.json
+++ b/custom_components/linksys_velop/manifest.json
@@ -9,7 +9,7 @@
   "issue_tracker": "https://github.com/uvjim/linksys_velop/issues",
   "name": "Linksys Velop",
   "requirements": [
-    "pyvelop>=2021.9.8"
+    "pyvelop==2021.10.5"
   ],
   "version": "2021.9.8"
 }

--- a/custom_components/linksys_velop/sensor.py
+++ b/custom_components/linksys_velop/sensor.py
@@ -88,7 +88,11 @@ class LinksysVelopMeshOnlineDevicesSensor(LinksysVelopMeshPolledSensor):
         return {
             "devices": [
                 {
-                    device.name: [adapter.get("ip") for adapter in device.network if adapter.get("ip")]
+                    device.name: {
+                        adapter.get("ip"): adapter.get("type")
+                        for adapter in device.network
+                        if adapter.get("ip")
+                    }
                 }
                 for device in self._get_devices(status=self._device_state)
             ]


### PR DESCRIPTION
- Change format of Mesh Online Devices sensor devices attribute. The attribute is now a dictionary in the format: -

```
DeviceName: {
  ip: adapter_type
}
```

- Bump requirement for `pyvelop`