### PR TITLE
Better manage missing or removed device trackers

### DIFF
--- a/custom_components/linksys_velop/config_flow.py
+++ b/custom_components/linksys_velop/config_flow.py
@@ -82,10 +82,15 @@ async def _async_build_schema_with_user_input(step: str, user_input: dict, **kwa
             ): cv.positive_int,
         }
     elif step == STEP_DEVICE_TRACKERS:
+        valid_trackers = [
+            tracker
+            for tracker in user_input.get(CONF_DEVICE_TRACKERS, [])
+            if tracker in kwargs["multi_select_contents"].keys()
+        ]
         schema = {
             vol.Optional(
                 CONF_DEVICE_TRACKERS,
-                default=user_input.get(CONF_DEVICE_TRACKERS, [])
+                default=valid_trackers
             ): cv.multi_select(kwargs["multi_select_contents"])
         }
 
@@ -244,6 +249,7 @@ class LinksysOptionsFlowHandler(config_entries.OptionsFlow):
         self._errors: dict = {}
         self._options: dict = dict(config_entry.options)
 
+    # noinspection PyUnusedLocal
     async def async_step_init(self, user_input=None) -> data_entry_flow.FlowResult:
         """"""
 


### PR DESCRIPTION
In addition to the warning that is logged on each device tracker scan interval, the integration will now put the device tracker entity in an unavailable state.

Rather than removing the device tracker entity, you can configure the integration.  When you reach the device tracker selection page, all those that are in an unavailable state will not be selected (as the Mesh doesn't know about them).  Clicking submit will remove the entities and tidy up the configuration (this will stop any warnings at startup).

A side effect seems to be that each time the configuration is updated for the integration the device trackers will go into an unavailable state until the first device tracker scan interval has completed.