### PR TITLE
Revert "Add the parent name of the device node to the event payload"

### DIFF
--- a/custom_components/linksys_velop/__init__.py
+++ b/custom_components/linksys_velop/__init__.py
@@ -66,7 +66,6 @@ EVENT_NEW_DEVICE_ON_MESH = f"{DOMAIN}_new_device_on_mesh"
 EVENT_NEW_DEVICE_ON_MESH_PROPERTIES = [
     "connected_adapters",
     "name",
-    "parent_name",
     "status",
 ]
 


### PR DESCRIPTION
Reverts uvjim/linksys_velop#132