### PR TITLE
add homekit switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ available.
 * Mesh: Client Steering _(disabled by default)_
 * Mesh: DHCP Server _(disabled by default)_
 * Mesh: Express Forwarding _(disabled by default)_
-* Mesh: HomeKit Integration _(disabled by default)_
 * Mesh: HomeKit Integration Paired _(disabled by default)_
 * Mesh: MAC Filtering _(disabled by default)_
   * mode, address list
@@ -154,6 +153,7 @@ install time and from reconfiguring the integration.
 
 * Mesh: Guest Wi-Fi state
   * list of guest networks available
+* Mesh: HomeKit Integration
 * Mesh: Parental Control state
   * list of the rules being applied
 * Mesh: WPS

--- a/custom_components/linksys_velop/binary_sensor.py
+++ b/custom_components/linksys_velop/binary_sensor.py
@@ -106,11 +106,6 @@ async def async_setup_entry(
         ),
         LinksysVelopBinarySensorDescription(
             entity_registry_enabled_default=False,
-            key="homekit_enabled",
-            name="HomeKit Integration",
-        ),
-        LinksysVelopBinarySensorDescription(
-            entity_registry_enabled_default=False,
             key="homekit_paired",
             name="HomeKit Integration Paired",
         ),
@@ -262,6 +257,15 @@ async def async_setup_entry(
                 description=LinksysVelopBinarySensorDescription(
                     key="",
                     name="Check for Updates Status",
+                ),
+            ),
+            LinksysVelopMeshBinarySensor(
+                config_entry=config_entry,
+                coordinator=coordinator,
+                description=LinksysVelopBinarySensorDescription(
+                    entity_registry_enabled_default=False,
+                    key="homekit_enabled",
+                    name="HomeKit Integration",
                 ),
             ),
             LinksysVelopMeshBinarySensor(

--- a/custom_components/linksys_velop/switch.py
+++ b/custom_components/linksys_velop/switch.py
@@ -91,6 +91,18 @@ async def async_setup_entry(
             },
         ),
         LinksysVelopSwitchDescription(
+            key="homekit_enabled",
+            name="HomeKit Integration",
+            turn_off="async_set_homekit_state",
+            turn_off_args={
+                "state": False,
+            },
+            turn_on="async_set_homekit_state",
+            turn_on_args={
+                "state": True,
+            },
+        ),
+        LinksysVelopSwitchDescription(
             extra_attributes=lambda m: (
                 {
                     "rules": {


### PR DESCRIPTION
removes the homekit integration binary sensor as it isn't needed anymore