### PR TITLE
chore: update manifest.json

### DIFF
--- a/custom_components/linksys_velop/manifest.json
+++ b/custom_components/linksys_velop/manifest.json
@@ -16,7 +16,7 @@
   ],
   "name": "Linksys Velop",
   "requirements": [
-    "pyvelop>=2024.7.1"
+    "pyvelop==2024.7.1"
   ],
   "ssdp": [
     {
@@ -24,5 +24,5 @@
       "manufacturer": "Linksys"
     }
   ],
-  "version": "2024.7.1"
+  "version": "2024.9.1"
 }


### PR DESCRIPTION
pin version of `pyvelop`
bump integration version