### PR TITLE
fix: disable speedtest button by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ enabled.
 * Mesh: Check for Updates
 * Mesh: Reboot the Whole Mesh (see [Configurable Options -> Advanced Options](#advanced-options))
 * Mesh: Start Channel Scanning _(interval: 40s)_
-* Mesh: Start Speedtest _(interval: 1s)_
+* Mesh: Start Speedtest _(interval: 1s)_ _(disabled by default)_
 * Node: Reboot
 
 > **N.B.** Buttons with an interval in brackets start a long running task.

--- a/custom_components/linksys_velop/button.py
+++ b/custom_components/linksys_velop/button.py
@@ -125,6 +125,7 @@ ENTITY_DETAILS: list[ButtonDetails] = [
     ButtonDetails(
         coordinator_type=CoordinatorTypes.SPEEDTEST,
         description=ButtonEntityDescription(
+            entity_registry_enabled_default=False,
             key="",
             name="Start Speedtest",
             translation_key="speedtest",


### PR DESCRIPTION
Established that Speedtest functionality is not available in bridge mode.  Seems best to disable the button for executing a Speedtest by default. The sensors were already disabled by default.