### PR TITLE
refactor(services)!: use config entry selector for services

### DIFF
--- a/custom_components/linksys_velop/service_handler.py
+++ b/custom_components/linksys_velop/service_handler.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import functools
 import logging
 import uuid
+from collections.abc import Awaitable
 
 import voluptuous as vol
 from homeassistant.core import HomeAssistant, ServiceCall
@@ -19,7 +20,6 @@ from pyvelop.node import Node, NodeType
 
 from .const import CONF_EVENTS_OPTIONS, DEF_EVENTS_OPTIONS, DOMAIN
 from .types import (
-    CoordinatorTypes,
     EventSubTypes,
     LinksysVelopConfigEntry,
     LinksysVelopLogFormatter,
@@ -119,7 +119,6 @@ class LinksysVelopServiceHandler:
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialise."""
         self._hass: HomeAssistant = hass
-        self._mesh: Mesh | None = None
         self._log_formatter: LinksysVelopLogFormatter = None
 
     def _get_config_entry_from_mesh_id(
@@ -141,19 +140,26 @@ class LinksysVelopServiceHandler:
 
         return config_entry
 
-    def _get_device(self, attribute: str, value: str) -> list[Device] | None:
-        """Get a device from the Mesh using the given attribute.
+    def _get_device(self, mesh: Mesh, value: str) -> list[Device] | None:
+        """Get a device from the Mesh based on name or unique ID.
 
         N.B. this uses the devices from the last poll to retrieve
         details.
         """
         ret: list[Device] | None = None
 
-        if isinstance(self._mesh, Mesh):
+        try:
+            _ = uuid.UUID(value)
             ret = [
                 device
-                for device in self._mesh.devices
-                if getattr(device, attribute, "").lower() == value.lower()
+                for device in mesh.devices
+                if getattr(device, "unique_id", "").lower() == value.lower()
+            ]
+        except ValueError:
+            ret = [
+                device
+                for device in mesh.devices
+                if getattr(device, "name", "").lower() == value.lower()
             ]
 
         return ret or None
@@ -164,38 +170,40 @@ class LinksysVelopServiceHandler:
         :param call: the service call that should be made
         :return: None
         """
-        _LOGGER.debug(self._log_formatter("entered, call: %s"), call)
 
         args = call.data.copy()
+        config_entry_id: str | None = args.pop("mesh", None)
+        config_entry: LinksysVelopConfigEntry
         if (
-            config_entry := self._get_config_entry_from_mesh_id(args.pop("mesh", ""))
-        ) is not None:
-            self._mesh = config_entry.runtime_data.coordinators.get(
-                CoordinatorTypes.MESH
-            )._mesh
-            _LOGGER.debug(self._log_formatter("Using %s"), self._mesh)
-            method = getattr(self, call.service, None)
-            if method:
-                try:
-                    await method(**args, config_entry=config_entry)
-                except MeshInvalidInput as exc:
-                    if call.service == "reboot_node":
-                        raise ServiceValidationError(
-                            translation_domain=DOMAIN,
-                            translation_key="invalid_input",
-                            translation_placeholders={
-                                "action": call.service,
-                                "original_msg": str(exc),
-                            },
-                        ) from exc
-                except Exception as err:
-                    _LOGGER.warning(
-                        self._log_formatter("%s", include_caller=False), err
-                    )
-        else:
-            _LOGGER.warning(
-                self._log_formatter("Unknown Mesh specified", include_caller=False)
-            )
+            config_entry := self._hass.config_entries.async_get_entry(config_entry_id)
+        ) is None:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_input",
+                translation_placeholders={
+                    "action": call.service,
+                    "original_msg": "Invalid Mesh specified",
+                },
+            ) from None
+
+        self._log_formatter = config_entry.runtime_data.log_formatter
+        _LOGGER.debug(self._log_formatter("entered, call: %s"), call)
+
+        _LOGGER.debug(self._log_formatter("Using %s"), config_entry.runtime_data.mesh)
+        if (method := getattr(self, call.service, None)) is not None:
+            try:
+                await method(**args, config_entry=config_entry)
+            except MeshInvalidInput as exc:
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="invalid_input",
+                    translation_placeholders={
+                        "action": call.service,
+                        "original_msg": str(exc),
+                    },
+                ) from exc
+            except Exception as err:
+                _LOGGER.warning(self._log_formatter("%s", include_caller=False), err)
 
         _LOGGER.debug(self._log_formatter("exited"))
 
@@ -220,11 +228,17 @@ class LinksysVelopServiceHandler:
         """Remove a device from the device list on the mesh."""
         _LOGGER.debug(self._log_formatter("entered, kwargs: %s"), kwargs)
 
+        coro: Awaitable[None]
         try:
             _ = uuid.UUID(kwargs.get("device"))
-            await self._mesh.async_delete_device_by_id(device=kwargs.get("device"))
+            coro = config_entry.runtime_data.mesh.async_delete_device_by_id
         except ValueError:
-            await self._mesh.async_delete_device_by_name(device=kwargs.get("device"))
+            coro = config_entry.runtime_data.mesh.async_delete_device_by_name
+
+        try:
+            await coro(kwargs.get("device"))
+        except Exception as exc:
+            raise MeshInvalidInput(str(exc)) from exc
 
         _LOGGER.debug(self._log_formatter("exited"))
 
@@ -234,18 +248,15 @@ class LinksysVelopServiceHandler:
         """Change state of Internet access for a device."""
         _LOGGER.debug(self._log_formatter("entered, %s"), kwargs)
 
-        try:
-            _ = uuid.UUID(kwargs.get("device"))
-            device: list[Device] | None = self._get_device(
-                attribute="unique_id", value=kwargs.get("device", "")
+        device: list[Device] | None = None
+        if (
+            device := self._get_device(
+                config_entry.runtime_data.mesh, kwargs.get("device", "")
             )
-        except ValueError:
-            device: list[Device] | None = self._get_device(
-                attribute="name", value=kwargs.get("device", "")
-            )
-
-        if device is None:
-            raise ValueError(f"Unknown device: {kwargs.get('device', '')}") from None
+        ) is None:
+            raise MeshInvalidInput(
+                f"Unknown device: {kwargs.get('device', '')}"
+            ) from None
 
         rules_to_apply: dict[str, str] = {}
         if kwargs.get("pause", False):
@@ -260,7 +271,7 @@ class LinksysVelopServiceHandler:
                 )
             )
 
-        await self._mesh.async_set_parental_control_rules(
+        await config_entry.runtime_data.mesh.async_set_parental_control_rules(
             device_id=device[0].unique_id,
             force_enable=True if kwargs.get("pause", False) else False,
             rules=rules_to_apply,
@@ -275,16 +286,14 @@ class LinksysVelopServiceHandler:
         _LOGGER.debug(self._log_formatter("entered, %s"), kwargs)
 
         device: list[Device] | None = None
-        try:
-            _ = uuid.UUID(kwargs.get("device"))
-            device = self._get_device(
-                attribute="unique_id", value=kwargs.get("device", "")
+        if (
+            device := self._get_device(
+                config_entry.runtime_data.mesh, kwargs.get("device", "")
             )
-        except ValueError:
-            device = self._get_device(attribute="name", value=kwargs.get("device", ""))
-
-        if device is None:
-            raise ValueError(f"Unknown device: {kwargs.get('device', '')}") from None
+        ) is None:
+            raise MeshInvalidInput(
+                f"Unknown device: {kwargs.get('device', '')}"
+            ) from None
 
         def _process_times() -> dict[str, str]:
             """Process the times from the service call."""
@@ -302,7 +311,7 @@ class LinksysVelopServiceHandler:
         rules_to_apply: dict[str, str] = _process_times()
         _LOGGER.debug(self._log_formatter("rules_to_apply: %s"), rules_to_apply)
 
-        await self._mesh.async_set_parental_control_rules(
+        await config_entry.runtime_data.mesh.async_set_parental_control_rules(
             device_id=device[0].unique_id,
             rules=rules_to_apply,
         )
@@ -322,10 +331,14 @@ class LinksysVelopServiceHandler:
         _LOGGER.debug(self._log_formatter("entered, kwargs: %s"), kwargs)
 
         node: Node = [
-            n for n in self._mesh.nodes if n.name == kwargs.get("node_name", "")
+            n
+            for n in config_entry.runtime_data.mesh.nodes
+            if n.name == kwargs.get("node_name", "")
         ]
         if len(node) == 0:
-            raise MeshInvalidInput(f"Unknown node: {kwargs.get('node_name', '')}")
+            raise MeshInvalidInput(
+                f"Unknown node: {kwargs.get('node_name', '')}"
+            ) from None
 
         if node[0].type == NodeType.SECONDARY:
             _LOGGER.warning(
@@ -338,8 +351,8 @@ class LinksysVelopServiceHandler:
                 "Use the button available on the node device.",
             )
 
-        await self._mesh.async_reboot_node(
-            node_name=kwargs.get("node_name", ""),
+        await config_entry.runtime_data.mesh.async_reboot_node(
+            kwargs.get("node_name", ""),
             force=kwargs.get("is_primary", False),
         )
 
@@ -363,18 +376,15 @@ class LinksysVelopServiceHandler:
         """Rename a device on the Mesh."""
         _LOGGER.debug(self._log_formatter("entered, kwargs: %s"), kwargs)
 
-        try:
-            _ = uuid.UUID(kwargs.get("device"))
-            device: list[Device] | None = self._get_device(
-                attribute="unique_id", value=kwargs.get("device", "")
+        device: list[Device] | None = None
+        if (
+            device := self._get_device(
+                config_entry.runtime_data.mesh, kwargs.get("device", "")
             )
-        except ValueError:
-            device: list[Device] | None = self._get_device(
-                attribute="name", value=kwargs.get("device", "")
-            )
-
-        if device is None:
-            raise ValueError(f"Unknown device: {kwargs.get('device', '')}") from None
+        ) is None:
+            raise MeshInvalidInput(
+                f"Unknown device: {kwargs.get('device', '')}"
+            ) from None
 
         # only make the request to rename if they are different
         if device[0].name != kwargs.get("new_name"):
@@ -382,7 +392,7 @@ class LinksysVelopServiceHandler:
                 self._log_formatter("renaming device: %s"),
                 device[0].unique_id,
             )
-            await self._mesh.async_rename_device(
+            await config_entry.runtime_data.mesh.async_rename_device(
                 device_id=device[0].unique_id, name=kwargs.get("new_name")
             )
 

--- a/custom_components/linksys_velop/services.yaml
+++ b/custom_components/linksys_velop/services.yaml
@@ -8,9 +8,8 @@ delete_device:
       description: The Mesh that the action should be executed on
       required: true
       selector:
-        device:
+        config_entry:
           integration: linksys_velop
-          manufacturer: uvjim
     device:
       name: Device
       description: The name or identifier of the device to rename
@@ -25,9 +24,8 @@ device_internet_access:
       description: The Mesh that the action should be executed on
       required: true
       selector:
-        device:
+        config_entry:
           integration: linksys_velop
-          manufacturer: uvjim
     device:
       name: Device
       description: The name or identifier of the device to pause/resume
@@ -48,9 +46,8 @@ device_internet_rules:
       description: The Mesh that the action should be executed on
       required: true
       selector:
-        device:
+        config_entry:
           integration: linksys_velop
-          manufacturer: uvjim
     device:
       name: Device
       description: The name or identifier of the device to apply the schedule to
@@ -478,9 +475,8 @@ reboot_node:
       description: The Mesh that the action should be executed on
       required: true
       selector:
-        device:
+        config_entry:
           integration: linksys_velop
-          manufacturer: uvjim
     node_name:
       name: "Name"
       description: The name of the node to reboot
@@ -503,9 +499,8 @@ rename_device:
       description: The Mesh that the action should be executed on
       required: true
       selector:
-        device:
+        config_entry:
           integration: linksys_velop
-          manufacturer: uvjim
     device:
       name: Device
       description: The name or identifier of the device to rename


### PR DESCRIPTION
Use the config entry selector for services rather than needing to specify the Mesh device ID.

This makes things more logical as you now only need to name the integration instance correctly rather than renaming the Mesh device to identify between two instances.

Automations, Action calls etc will need to be updated to reflect this.

Better exception handling has also been introduced.