### PR TITLE
fix: safely identify unnamed devices in placeholder select

### DIFF
--- a/custom_components/linksys_velop/select.py
+++ b/custom_components/linksys_velop/select.py
@@ -67,6 +67,17 @@ def get_current_reboot_schedule(mesh: Mesh, *args) -> str | None:
     return ret
 
 
+def get_placeholder_device_identifier(device: DeviceEntity) -> str:
+    """Return the identifier displayed for an unnamed placeholder device."""
+
+    if device.status:
+        adapter = next(iter(device.adapter_info), None)
+        if adapter is not None and adapter.ip is not None:
+            return adapter.ip
+
+    return str(device.unique_id)
+
+
 def get_placeholder_device_options(mesh: Mesh) -> dict[str, str]:
     """Retrieve the list of device options available for the placeholder device."""
 
@@ -76,7 +87,7 @@ def get_placeholder_device_options(mesh: Mesh) -> dict[str, str]:
         name: str = (
             d.name
             if d.name != EMPTY_NAME
-            else f"{d.name} ({next(iter(d.adapter_info), {}).get('ip') if d.status else d.unique_id})"
+            else f"{d.name} ({get_placeholder_device_identifier(d)})"
         )
         if d.unique_id is not None:
             ret[d.unique_id] = name
@@ -109,8 +120,8 @@ async def async_update_placeholder_device(mesh: Mesh, option: str) -> None:
     )
     for dev in mesh.devices:
         match_against: list[str] = [dev.name.lower(), str(dev.unique_id)]
-        if option.startswith(f"{EMPTY_NAME} (") and dev.status:
-            match_against.append(dev.adapter_info[0].get("ip", ""))
+        if option.startswith(f"{EMPTY_NAME} ("):
+            match_against.append(get_placeholder_device_identifier(dev))
         if match_on.lower() in match_against:
             velop_id = dev.unique_id
             break


### PR DESCRIPTION
## Summary

- Safely retrieve the identifier used for unnamed devices in the temporary-device select.
- Use the same identifier for option display and reverse lookup.
- Fall back to the device unique ID when no adapter IP is available.

## Context

`pyvelop 2026.8.9` represents adapter information using the `AdapterInfo` dataclass rather than dictionaries.

#648 updated the adapter-based binary sensors accordingly, but two dictionary-style accesses remained in the temporary-device paths in `select.py`:

```python
next(iter(d.adapter_info), {}).get("ip")
dev.adapter_info[0].get("ip", "")
```

Those calls fail when their paths receive an `AdapterInfo` instance. The second access can also fail if the adapter list is empty.

This change uses a single helper for both option generation and reverse lookup so that the displayed identifier can always be mapped back consistently.

## Scope

My live configuration does not enable the temporary-device selector, so this finding is based on source inspection rather than a claimed live reproduction.

The change is limited to placeholder-device selection and does not affect ordinary UI devices, device status, relationships, or mesh polling.

## Validation

- `ruff format --check custom_components/linksys_velop/select.py`
- `ruff check custom_components/linksys_velop/select.py --ignore C414`
- Parsed all 20 integration Python files with Python's AST parser.
- Exercised five targeted option-generation and reverse-lookup cases: named, unnamed online with an IP, unnamed online with no adapters, unnamed online with an adapter but no IP, and unnamed offline.
- `git diff --check`

`select.py` retains an existing `C414` finding at an unchanged `options_fn`; the repository-wide Ruff baseline also reports unrelated existing findings.

## AI assistance

This change and its description were prepared with assistance from OpenAI Codex. The contributor reviewed the resulting diff and validation evidence before submission.
